### PR TITLE
Add more JSON routes and be more RESTful

### DIFF
--- a/src/serve.py
+++ b/src/serve.py
@@ -4,7 +4,7 @@ from common import fixup_book_for_index
 from datetime import datetime
 from elasticsearch import Elasticsearch
 from elasticsearch.exceptions import ConflictError, NotFoundError
-from flask import Flask, abort, jsonify, redirect, render_template, request, send_from_directory
+from flask import Flask, abort, jsonify, make_response, redirect, render_template, request, send_from_directory
 
 import os
 import re
@@ -120,6 +120,10 @@ def transform_book(bId, book):
     return book
 
 
+###############################################################################
+## Search helpers
+
+
 def sort_key_for_book(book):
     return (
         book["bucket"],
@@ -205,6 +209,10 @@ def do_search(request_args):
         "count": len(hits),
         "search_params": search_params,
     }
+
+
+###############################################################################
+## Form helpers
 
 
 def is_invalid_isbn(code):
@@ -308,6 +316,10 @@ def form_to_book(form, files, this_is_an_insert=True):
     return bId, fixup_book_for_index(book), cover, errors
 
 
+###############################################################################
+## Response helpers
+
+
 def standard_template_args():
     all_books = do_search({})
 
@@ -322,54 +334,154 @@ def standard_template_args():
     }
 
 
+def accepts_html(fmt, request):
+    return fmt in ["*", "html"] and request.accept_mimetypes.accept_html
+
+
+def accepts_json(fmt, request):
+    return fmt in ["*", "json"] and request.accept_mimetypes.accept_json
+
+
+def unacceptable(fmt, request):
+    return not accepts_html(fmt, request) and not accepts_json(fmt, request)
+
+
+def fmt_errors(fmt, request, book, errors):
+    if accepts_html(fmt, request):
+        return render_template("edit.html", book=book, errors=errors, **standard_template_args())
+    elif accepts_json(fmt, request):
+        return jsonify(errors)
+    else:
+        abort(500)  # unreachable if 'unacceptable' is checked
+
+
+def fmt_message(fmt, request, message):
+    if accepts_html(fmt, request):
+        return render_template("info.html", message=message, base_uri=BASE_URI)
+    elif accepts_json(fmt, request):
+        return jsonify({"message": message})
+    else:
+        abort(500)  # unreachable if 'unacceptable' is checked
+
+
+###############################################################################
+## Controllers
+
+
+def do_create_book(fmt, request):
+    bId, candidate, cover, errors = form_to_book(request.form, request.files)
+    if errors:
+        return fmt_errors(fmt, request, candidate, errors), 422
+
+    try:
+        es.create(index="bookdb", id=bId, body=candidate)
+    except ConflictError:
+        return fmt_errors(fmt, request, candidate, ["Code already in use"]), 409
+
+    if cover:
+        cover.save(os.path.join(COVER_DIR, bId))
+
+    resp = make_response(fmt_message(fmt, request, "The book has been created."), 201)
+    resp.headers["Location"] = f"{BASE_URI}/book/{bId}"
+    return resp
+
+
+def do_update_book(bId, book, fmt, request):
+    _, candidate, cover, errors = form_to_book(request.form, request.files, this_is_an_insert=False)
+    if errors:
+        return fmt_errors(fmt, request, {"id": bId, **candidate}, errors), 422
+
+    es.update(index="bookdb", id=bId, body={"doc": candidate})
+
+    if cover:
+        cover.save(os.path.join(COVER_DIR, bId))
+
+    return fmt_message(fmt, request, "The book has been updated.")
+
+
+def do_delete_book(bId, fmt, request):
+    es.delete(index="bookdb", id=bId)
+    return fmt_message(fmt, request, "The book has been deleted.")
+
+
+###############################################################################
+## Routes
+
+
 @app.route("/")
-def redirect_index():
-    return redirect(f"{BASE_URI}/search", code=301)
-
-
 @app.route("/list")
-def redirect_list():
+def redirect_to_search():
     return redirect(f"{BASE_URI}/search", code=301)
 
 
-@app.route("/search")
-def search():
+@app.route("/search", defaults={"fmt": "*"})
+@app.route("/search.<fmt>")
+def search(fmt):
+    if unacceptable(fmt, request):
+        abort(406)
+
     results = do_search(request.args)
 
-    num_read = results["aggregations"]["match"].get("only-read", 0)
-    return render_template(
-        "search.html",
-        books=results["books"],
-        num_authors=len(results["aggregations"]["author"]),
-        num_read=num_read,
-        percent_read=int((num_read / results["count"]) * 100) if results["count"] > 0 else 100,
-        search_params=results["search_params"],
-        **standard_template_args(),
-    )
+    if accepts_html(fmt, request):
+        num_read = results["aggregations"]["match"].get("only-read", 0)
+        return render_template(
+            "search.html",
+            books=results["books"],
+            num_authors=len(results["aggregations"]["author"]),
+            num_read=num_read,
+            percent_read=int((num_read / results["count"]) * 100) if results["count"] > 0 else 100,
+            search_params=results["search_params"],
+            **standard_template_args(),
+        )
+    else:
+        return jsonify(results)
 
 
-@app.route("/add", methods=["GET", "HEAD", "POST"])
-def add():
+@app.route("/book/<bId>", methods=["GET", "PUT", "DELETE", "HEAD"], defaults={"fmt": "*"})
+@app.route("/book/<bId>.<fmt>", methods=["GET", "PUT", "DELETE", "HEAD"])
+def book_controller(bId, fmt):
+    if unacceptable(fmt, request):
+        abort(406)
+
+    book = get_book(bId)
+    if not book:
+        abort(404)
+
+    if request.method == "PUT":
+        return do_update_book(bId, book, fmt, request)
+    elif request.method == "DELETE":
+        return do_delete_book(bId, fmt, request)
+    else:
+        if accepts_json(fmt, request):
+            return jsonify(book)
+        else:
+            abort(406)  # reachable
+
+
+@app.route("/add", methods=["GET", "HEAD", "POST"], defaults={"fmt": "*"})
+@app.route("/add.<fmt>", methods=["GET", "HEAD", "POST"])
+def add(fmt):
+    if unacceptable(fmt, request):
+        abort(406)
+
     if not ALLOW_WRITES:
         abort(403)
 
     if request.method == "POST":
-        bId, candidate, cover, errors = form_to_book(request.form, request.files)
-        if errors:
-            return render_template("edit.html", book=candidate, errors=errors, **standard_template_args())
-        try:
-            es.create(index="bookdb", id=bId, body=candidate)
-        except ConflictError:
-            return render_template("edit.html", book=candidate, errors=["Code already in use"], **standard_template_args())
-        if cover:
-            cover.save(os.path.join(COVER_DIR, bId))
-        return render_template("info.html", message="The book has been created.", base_uri=BASE_URI)
+        return do_create_book(fmt, request)
 
-    return render_template("edit.html", book={}, **standard_template_args())
+    if accepts_html(fmt, request):
+        return render_template("edit.html", book={}, **standard_template_args())
+    else:
+        abort(406)  # reachable
 
 
-@app.route("/book/<bId>/edit", methods=["GET", "HEAD", "POST"])
-def edit(bId):
+@app.route("/book/<bId>/edit", methods=["GET", "HEAD", "POST"], defaults={"fmt": "*"})
+@app.route("/book/<bId>/edit.<fmt>", methods=["GET", "HEAD", "POST"])
+def edit(bId, fmt):
+    if unacceptable(fmt, request):
+        abort(406)
+
     if not ALLOW_WRITES:
         abort(403)
 
@@ -378,19 +490,20 @@ def edit(bId):
         abort(404)
 
     if request.method == "POST":
-        _, candidate, cover, errors = form_to_book(request.form, request.files, this_is_an_insert=False)
-        if errors:
-            return render_template("edit.html", book={"id": bId, **candidate}, errors=errors, **standard_template_args())
-        es.update(index="bookdb", id=bId, body={"doc": candidate})
-        if cover:
-            cover.save(os.path.join(COVER_DIR, bId))
-        return render_template("info.html", message="The book has been updated.", base_uri=BASE_URI)
+        return do_update_book(bId, book, fmt, request)
 
-    return render_template("edit.html", book=book, **standard_template_args())
+    if accepts_html(fmt, request):
+        return render_template("edit.html", book=book, **standard_template_args())
+    else:
+        abort(406)  # reachable
 
 
-@app.route("/book/<bId>/delete", methods=["GET", "HEAD", "POST"])
-def delete(bId):
+@app.route("/book/<bId>/delete", methods=["GET", "HEAD", "POST"], defaults={"fmt": "html"})
+@app.route("/book/<bId>/delete.<fmt>", methods=["GET", "HEAD", "POST"])
+def delete(bId, fmt):
+    if unacceptable(fmt, request):
+        abort(406)
+
     if not ALLOW_WRITES:
         abort(403)
 
@@ -399,23 +512,12 @@ def delete(bId):
         abort(404)
 
     if request.method == "POST":
-        es.delete(index="bookdb", id=bId)
-        return render_template("info.html", message="The book has been deleted.", base_uri=BASE_URI)
+        return do_delete_book(bId, fmt, request)
 
-    return render_template("delete.html", book=book, base_uri=BASE_URI)
-
-
-@app.route("/search.json")
-def search_json():
-    return jsonify(do_search(request.args))
-
-
-@app.route("/book/<bId>.json")
-def book_json(bId):
-    book = get_book(bId)
-    if not book:
-        abort(404)
-    return jsonify(book)
+    if accepts_html(fmt, request):
+        return render_template("delete.html", book=book, base_uri=BASE_URI)
+    else:
+        abort(406)  # reachable
 
 
 @app.route("/book/<bId>/cover")

--- a/src/templates/error.html
+++ b/src/templates/error.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <base href="{{ base_uri|e }}">
+    <title>Error {{ code|e }}</title>
+
+    <link rel="stylesheet" href="static/style.css" type="text/css">
+  </head>
+
+  <body>
+    <div class="info">
+      <p>{{ message|e }}</p>
+      <p><a href="search">Click here to continue.</a></p>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
All the core now routes take an optional `.<fmt>` suffix.  The two allowed formats (other than for static files and cover images) are `application/json` and `text/html`: if `fmt` is "json" or "html", and the `Accept` header matches, then the response will be returned in that format.

The core routes are now:

    GET    /search              -> do search
    GET    /book/<id>           -> get book details (only json)
    PUT    /book/<id>           -> update book
    DELETE /book/<id>           -> delete book
    GET    /add                 -> render add form (only html)
    POST   /add                 -> create book
    GET    /book/<id>/edit      -> render edit form (only html)
    POST   /book/<id>/edit      -> alias for PUT /book/<id>
    GET    /book/<id>/delete    -> render delete form (only html)
    POST   /book/<id>/delete    -> alias for DELETE /book/<id>
    GET    /book/<id>/cover     -> get cover image (multiple formats)
    GET    /static/<file>       -> get static file (multiple formats)

The following redirects exist for legacy purposes:

    GET    /                    -> redirect to /search
    GET    /list                -> redirect to /search

As these only exist to redirect any existing links, they do not have the optional `.<fmt>` suffix.