### PR TITLE
Use exec form for Dockerfile CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ USER app
 
 ENV ELASTIC_CLIENT_APIVERSIONING=1
 
-CMD gunicorn -w 4 -b 0.0.0.0:8888 serve:app
+CMD ["gunicorn", "-w", "4", "-b", "0.0.0.0:8888", "serve:app"]


### PR DESCRIPTION
The shell form prevents signals from propagating to `gunicorn`.