### PR TITLE
Merge all subcategories of Prose Fiction + Graphic Novels

### DIFF
--- a/config/uuids.yaml
+++ b/config/uuids.yaml
@@ -34,13 +34,6 @@ ordered_categories:
 
 - name: Prose Fiction + Graphic Novels
   uuid: 590ac55d-0644-4a71-b902-587faa5b03d9
-  ordered_children:
-  - name: Gothic, Horror, + Weird
-    uuid: c2bfb2d8-ce64-4480-aaa6-c2d2dcb34ace
-  - name: High Fantasy
-    uuid: bcb54905-2e45-4a8f-bda0-e1d12e4114d2
-  - name: Miscellaneous
-    uuid: ea4e9b04-3ebb-4ff3-b387-d8bfc603f58a
 
 - name: Religion, Mythology, + Folklore
   uuid: a7d83bc9-0352-4fb5-a9dc-68428562a17f


### PR DESCRIPTION
I've run out of shelf space and can reclaim a little by not
maintaining these as separate collections, and also the distinction
just raises unhelpful ambiguities.