### PR TITLE
Remove refresh tag from delete template

### DIFF
--- a/bookdb/templates/delete.html
+++ b/bookdb/templates/delete.html
@@ -4,8 +4,6 @@
     <base href="{{ base_uri|e }}">
     <title>Delete</title>
 
-    <meta http-equiv="refresh" content="2;URL='{{ base_url|e }}/search'">
-
     <link rel="stylesheet" href="static/style.css" type="text/css">
   </head>
 


### PR DESCRIPTION
This was probably mis-copied from the info template in 2020 and I've just never noticed because I barely ever get rid of a book.