### PR TITLE
Save new cover images with mode 644

### DIFF
--- a/src/web/endpoints.rs
+++ b/src/web/endpoints.rs
@@ -469,6 +469,13 @@ impl AppState {
             .await
             .map_err(|_| errors::something_went_wrong())?;
 
+        fs::set_permissions(
+            cover_path.clone(),
+            std::os::unix::fs::PermissionsExt::from_mode(0o644),
+        )
+        .await
+        .map_err(|_| errors::something_went_wrong())?;
+
         fs::remove_file(tmp_path)
             .await
             .map_err(|_| errors::something_went_wrong())?;


### PR DESCRIPTION
This is more convenient for backup / sync scripts which ideally shouldn't have to use `sudo` to copy the files.