### PR TITLE
Add support for reference books

### DIFF
--- a/src/book.rs
+++ b/src/book.rs
@@ -16,10 +16,11 @@ pub struct Book {
     pub inner: BookV1,
 }
 
-impl<'de> Deserialize<'de> for Book {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+impl Book {
+    // cannot implement serde::Deserialize because of the need to copy
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: serde::Deserializer<'de> + Copy,
     {
         match BookV1::deserialize(deserializer) {
             Ok(inner) => Ok(Book { inner }),

--- a/src/es.rs
+++ b/src/es.rs
@@ -5,7 +5,6 @@ use elasticsearch::{
     BulkParts, ClearScrollParts, DeleteParts, Elasticsearch, Error, GetParts, IndexParts,
     ScrollParts, SearchParts,
 };
-use serde::Deserialize;
 use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::default::Default;

--- a/src/es.rs
+++ b/src/es.rs
@@ -73,7 +73,10 @@ pub async fn get(client: &Elasticsearch, code: Code) -> Result<Option<Book>, Err
 pub async fn put(client: &Elasticsearch, book: Book) -> Result<(), Error> {
     let source = &serialise(&book)["_source"];
     client
-        .index(IndexParts::IndexId(INDEX_NAME, &book.code.to_string()))
+        .index(IndexParts::IndexId(
+            INDEX_NAME,
+            &book.inner.code.to_string(),
+        ))
         .op_type(OpType::Create)
         .body(source)
         .send()
@@ -240,7 +243,7 @@ pub fn serialise(book: &Book) -> Value {
         Value::String(book.display_title()),
     );
     map.remove("code");
-    json!({ "_id": book.code.to_string(), "_source": source })
+    json!({ "_id": book.inner.code.to_string(), "_source": source })
 }
 
 pub fn try_deserialise(hit: &Value) -> Result<Book, DeserialiseBookError> {

--- a/src/es.rs
+++ b/src/es.rs
@@ -9,7 +9,7 @@ use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::default::Default;
 
-use crate::book::{Book, Code, ParseCodeError};
+use crate::book::{Book, Code, HasBeenRead, ParseCodeError};
 use crate::config::Slug;
 
 static INDEX_NAME: &str = "bookdb";
@@ -30,7 +30,7 @@ pub async fn create(client: &Elasticsearch) -> Result<(), Error> {
                     "authors": { "type": "keyword" },
                     "translators": { "type": "keyword" },
                     "editors": { "type": "keyword" },
-                    "has_been_read": { "type": "boolean" },
+                    "has_been_read": { "type": "keyword" },
                     "last_read_date": { "type": "date", "format": "yyyy-MM-dd" },
                     "cover_image_mimetype": { "type": "keyword" },
                     "holdings": {
@@ -94,7 +94,7 @@ pub async fn delete(client: &Elasticsearch, code: Code) -> Result<(), Error> {
 #[derive(Default)]
 pub struct SearchQuery {
     pub keywords: Option<String>,
-    pub read: Option<bool>,
+    pub read: Option<HasBeenRead>,
     pub location: Option<Slug>,
     pub categories: Vec<Slug>,
     pub people: Vec<String>,
@@ -149,54 +149,30 @@ pub struct SearchResultAggs {
     pub author: HashMap<String, u64>,
     pub translator: HashMap<String, u64>,
     pub editor: HashMap<String, u64>,
-    pub read: u64,
-    pub unread: u64,
-    pub category: HashMap<Slug, u64>,
-    pub location: HashMap<Slug, u64>,
 }
 
 pub async fn search(client: &Elasticsearch, query: SearchQuery) -> Result<SearchResult, Error> {
-    let res = scroll(client, json!({
-        "query": query.build_query_json(),
-        "aggs": {
-            "author": {"terms": {"field": "authors", "size": 1000}},
-            "editor": {"terms": {"field": "editors", "size": 500}},
-            "translator": {"terms": {"field": "translators", "size": 500}},
-            "has_been_read": {"terms": {"field": "has_been_read", "size": 500}},
-            "category": {"terms": {"field": "category", "size": 500}},
-            "holdings": {"nested": {"path": "holdings"}, "aggs": {"location": {"terms": {"field": "holdings.location", "size": 500}}}},
-        },
-    })).await?;
-
-    let mut aggs = SearchResultAggs {
-        author: agg_buckets_to_hashmap(&res.aggs["author"]["buckets"]),
-        editor: agg_buckets_to_hashmap(&res.aggs["editor"]["buckets"]),
-        translator: agg_buckets_to_hashmap(&res.aggs["translator"]["buckets"]),
-        read: 0,
-        unread: 0,
-        category: HashMap::new(),
-        location: HashMap::new(),
-    };
-    for (key, doc_count) in agg_buckets_to_hashmap(&res.aggs["has_been_read"]["buckets"]).drain() {
-        if key == "true" {
-            aggs.read = doc_count;
-        } else {
-            aggs.unread = doc_count;
-        }
-    }
-    for (key, doc_count) in agg_buckets_to_hashmap(&res.aggs["category"]["buckets"]).drain() {
-        aggs.category.insert(Slug(key), doc_count);
-    }
-    for (key, doc_count) in
-        agg_buckets_to_hashmap(&res.aggs["holdings"]["location"]["buckets"]).drain()
-    {
-        aggs.location.insert(Slug(key), doc_count);
-    }
+    let res = scroll(
+        client,
+        json!({
+            "query": query.build_query_json(),
+            "aggs": {
+                "author": {"terms": {"field": "authors", "size": 1000}},
+                "editor": {"terms": {"field": "editors", "size": 500}},
+                "translator": {"terms": {"field": "translators", "size": 500}},
+            },
+        }),
+    )
+    .await?;
 
     Ok(SearchResult {
         count: res.hits.len(),
         hits: res.hits,
-        aggs,
+        aggs: SearchResultAggs {
+            author: agg_buckets_to_hashmap(&res.aggs["author"]["buckets"]),
+            editor: agg_buckets_to_hashmap(&res.aggs["editor"]["buckets"]),
+            translator: agg_buckets_to_hashmap(&res.aggs["translator"]["buckets"]),
+        },
     })
 }
 

--- a/src/web/_resources/edit.html.tera
+++ b/src/web/_resources/edit.html.tera
@@ -65,7 +65,12 @@
           <div class="form-row">
             <div class="form-group">
               <label class="form-label" for="has_been_read">Has Been Read</label>
-              <input class="form-input form-input--zerowidth" type="checkbox" id="has_been_read" name="has_been_read"{% if book.has_been_read %} checked{% endif %}>
+              <select class="form-input form-input--narrow" id="has_been_read" name="has_been_read">
+                <option></option>
+                <option value="read" {% if book.has_been_read == "read" %}selected{% endif %}>Yes</option>
+                <option value="unread" {% if book.has_been_read == "unread" %}selected{% endif %}>No</option>
+                <option value="not-applicable" {% if book.has_been_read == "not-applicable" %}selected{% endif %}>Not Applicable</option>
+              </select>
             </div>
             <div class="form-group">
               <label class="form-label" for="last_read_date">Last Read Date</label>

--- a/src/web/_resources/search.html.tera
+++ b/src/web/_resources/search.html.tera
@@ -38,8 +38,9 @@
                   <label class="form-label" for="match">Show</label>
                   <select class="form-input form-input--narrow" id="match" name="match">
                     <option></option>
-                    <option value="only-read" {% if query.match == "only-read" %}selected{% endif %}>Only read books</option>
-                    <option value="only-unread" {% if query.match == "only-unread" %}selected{% endif %}>Only unread books</option>
+                    <option value="read" {% if query.match == "read" %}selected{% endif %}>Only read books</option>
+                    <option value="unread" {% if query.match == "unread" %}selected{% endif %}>Only unread books</option>
+                    <option value="not-applicable" {% if query.match == "not-applicable" %}selected{% endif %}>Only reference books</option>
                   </select>
                 </div>
               </div>
@@ -74,8 +75,7 @@
         {% else %}
         <p>
           Showing {{ num_books }} {% if num_books == 1 %}book{% else %}books{% endif %}
-          by {{ num_authors }} {% if num_authors == 1 %}author{% else %}authors{% endif %},
-          of which {{ num_read }} ({{ percent_read }}%) {% if num_read == 1 %}has{% else %}have{% endif %} been read.
+          by {{ num_authors }} {% if num_authors == 1 %}author{% else %}authors{% endif %}.
         </p>
 
         <table id="search-results">
@@ -103,11 +103,9 @@
                 </ol>
               </td>
               <td class="narrow-hide">
-                {% if book.has_been_read %}
-                ✔{% if book.last_read_date %} ({{ book.last_read_date }}){% endif %}
-                {% else %}
-                ✘
-                {% endif %}
+                {% if book.has_been_read == "read" %}✔{% if book.last_read_date %} ({{ book.last_read_date }}){% endif %}{% endif %}
+                {% if book.has_been_read == "unread" %}✘{% endif %}
+                {% if book.has_been_read == "not-applicable" %}&mdash;{% endif %}
               </td>
               <td class="category">
                 <ol class="detail-list">

--- a/src/web/errors.rs
+++ b/src/web/errors.rs
@@ -43,7 +43,10 @@ pub fn cannot_connect_to_search_server() -> Error {
 pub fn book_does_not_have_cover_image(book: &Book) -> Error {
     Error {
         status_code: StatusCode::NOT_FOUND,
-        message: format!("The book '{}' does not have a cover image set.", book.code),
+        message: format!(
+            "The book '{}' does not have a cover image set.",
+            book.inner.code
+        ),
     }
 }
 

--- a/src/web/model.rs
+++ b/src/web/model.rs
@@ -8,7 +8,7 @@ use time::Date;
 use tokio::fs::File as AsyncFile;
 use tokio::io::AsyncWriteExt;
 
-use crate::book::{Book, BookDisplayTitle, Code, Holding};
+use crate::book::{Book, BookDisplayTitle, BookV1, Code, Holding};
 use crate::config::Slug;
 
 #[derive(Debug, Default)]
@@ -34,25 +34,26 @@ pub struct BookForm {
 impl std::convert::From<Book> for BookForm {
     fn from(book: Book) -> Self {
         Self {
-            code: Some(book.code),
-            cover_image_mimetype: book.cover_image_mimetype,
-            category_slug: Some(book.category),
-            title: Some(book.title),
-            subtitle: book.subtitle,
-            volume_title: book.volume_title,
-            volume_number: book.volume_number,
-            fascicle_number: book.fascicle_number,
-            has_been_read: book.has_been_read,
-            last_read_date: book.last_read_date,
-            authors: book.authors,
-            editors: book.editors.unwrap_or_default(),
-            translators: book.translators.unwrap_or_default(),
+            code: Some(book.inner.code),
+            cover_image_mimetype: book.inner.cover_image_mimetype,
+            category_slug: Some(book.inner.category),
+            title: Some(book.inner.title),
+            subtitle: book.inner.subtitle,
+            volume_title: book.inner.volume_title,
+            volume_number: book.inner.volume_number,
+            fascicle_number: book.inner.fascicle_number,
+            has_been_read: book.inner.has_been_read,
+            last_read_date: book.inner.last_read_date,
+            authors: book.inner.authors,
+            editors: book.inner.editors.unwrap_or_default(),
+            translators: book.inner.translators.unwrap_or_default(),
             holdings: book
+                .inner
                 .holdings
                 .into_iter()
                 .map(|h| (h.location, h.note.unwrap_or_default()))
                 .collect(),
-            bucket: Some(book.bucket),
+            bucket: Some(book.inner.bucket),
             form_errors: Vec::new(),
         }
     }
@@ -159,28 +160,30 @@ impl BookForm {
         };
 
         Ok(Book {
-            code: self.code.unwrap(),
-            title: self.title.unwrap(),
-            subtitle: self.subtitle,
-            volume_title: self.volume_title,
-            volume_number: self.volume_number,
-            fascicle_number: self.fascicle_number,
-            authors: self.authors,
-            editors: Some(self.editors),
-            translators: Some(self.translators),
-            has_been_read: self.has_been_read,
-            last_read_date: self.last_read_date,
-            cover_image_mimetype: self.cover_image_mimetype,
-            holdings: self
-                .holdings
-                .into_iter()
-                .map(|(location, n)| Holding {
-                    location,
-                    note: if n.is_empty() { None } else { Some(n) },
-                })
-                .collect(),
-            bucket: self.bucket.unwrap_or(default_bucket),
-            category: self.category_slug.unwrap(),
+            inner: BookV1 {
+                code: self.code.unwrap(),
+                title: self.title.unwrap(),
+                subtitle: self.subtitle,
+                volume_title: self.volume_title,
+                volume_number: self.volume_number,
+                fascicle_number: self.fascicle_number,
+                authors: self.authors,
+                editors: Some(self.editors),
+                translators: Some(self.translators),
+                has_been_read: self.has_been_read,
+                last_read_date: self.last_read_date,
+                cover_image_mimetype: self.cover_image_mimetype,
+                holdings: self
+                    .holdings
+                    .into_iter()
+                    .map(|(location, n)| Holding {
+                        location,
+                        note: if n.is_empty() { None } else { Some(n) },
+                    })
+                    .collect(),
+                bucket: self.bucket.unwrap_or(default_bucket),
+                category: self.category_slug.unwrap(),
+            },
         })
     }
 


### PR DESCRIPTION
aka remove the yes/no has-been-read dichotomy!

Having a growing number of unread books makes me feel bad, so this PR:

1. Introduces a way to migrate the model representation forwards
2. Adds a third state: "not-applicable", which is surfaced in the UI as "is a reference book" more-or-less
3. Removes the line about what proportion of books have been read.

An unexpected upside is that this allows simplifying some code, as I can delete some aggregations and template variables that I don't need any more.

As this changes the ES schema, for search to work the index will have to be dumped and restored, but that's an easy operation now.